### PR TITLE
Fix visit structure

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: secuTrialR
 Type: Package
 Title: Handling of data from the clinical data management system secuTrial 
-Version: 0.3.8
+Version: 0.3.7
 Authors@R:
     c(person(given = "Pascal",
              family = "Benkert",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: secuTrialR
 Type: Package
 Title: Handling of data from the clinical data management system secuTrial 
-Version: 0.3.6
+Version: 0.3.7
 Authors@R:
     c(person(given = "Pascal",
              family = "Benkert",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: secuTrialR
 Type: Package
 Title: Handling of data from the clinical data management system secuTrial 
-Version: 0.3.7
+Version: 0.3.8
 Authors@R:
     c(person(given = "Pascal",
              family = "Benkert",

--- a/R/visit_structure.R
+++ b/R/visit_structure.R
@@ -40,22 +40,17 @@ visit_structure <- function(x){
                timevar = "mnpvislabel",
                idvar = "formname", v.names = "tmpvar")
   # column order
-  tmpl <- split(vp, vp$mnpvsno)
-  w <- which(sapply(tmpl, function(x) all(unique(u$mnpvislabel) %in% x$mnpvislabel)))[1]
-  tmpl <- tmpl[[w]]
-  tmpl <- tmpl[!duplicated(tmpl$mnpvislabel), ]
-  tmpl$r <- 1:nrow(tmpl)
-  neworder <- c(1, tmpl$r[match(tmpl$mnpvislabel, gsub("tmpvar.", "", names(r)[2:ncol(r)]))] + 1)
-  r <- r[, neworder]
+  visits <- aggregate(visitnumber ~ mnpvislabel, vp, min)
+  vis_order <- as.character(visits$mnpvislabel[order(visits$visitnumber)])
   # row order
-  tmpl <- split(f, f$mnpvslbl)
-  w <- which(sapply(tmpl, function(x) all(unique(u$formname) %in% x$formname)))[1]
-  tmpl <- tmpl[[1]]
-  f <- as.character(tmpl$formname)
-  neworder <- na.exclude( (1:length(f))[match(f, r$formname)])
-  ro <- r[neworder, ]
-  names <- gsub("tmpvar.", "", names(ro[, grepl("tmpvar", names(ro))]))
-  names(ro)[2:ncol(ro)] <- names
+  ff <- aggregate(formid ~ formname, f, min)
+  form_order <- as.character(ff$formname[order(ff$formid)])
+
+  # adjust names
+  rownames(r) <- r["formname", ]
+  names(r) <- gsub("tmpvar.", "", names(r))
+
+  ro <- r[form_order, c("formname", vis_order)]
 
   class(ro) <- c("secuTrialvisit", "data.frame")
   return(ro)

--- a/R/visit_structure.R
+++ b/R/visit_structure.R
@@ -40,14 +40,15 @@ visit_structure <- function(x){
                timevar = "mnpvislabel",
                idvar = "formname", v.names = "tmpvar")
   # column order
-  visits <- aggregate(visitnumber ~ mnpvislabel, vp, min)
+  visits <- aggregate(visitnumber ~ mnpvislabel, vp, median)
   vis_order <- as.character(visits$mnpvislabel[order(visits$visitnumber)])
   # row order
-  ff <- aggregate(formid ~ formname, f, min)
+  ff <- aggregate(formid ~ formname, f, median)
   form_order <- as.character(ff$formname[order(ff$formid)])
+  form_order <- intersect(form_order, r$formname)
 
   # adjust names
-  rownames(r) <- r["formname", ]
+  rownames(r) <- r$formname
   names(r) <- gsub("tmpvar.", "", names(r))
 
   ro <- r[form_order, c("formname", vis_order)]


### PR DESCRIPTION
fix issue #20 
reordering of columns and rows did not work, if some visits were missing.
columns: reordering did not work in visit_structure, if no list item of tmpl contained all visitlabels. I replaced ordering of visitlabels by the median visitnumber of vp. The median leads to the most realistic ordering of columns. 
rows: reordering of rows was wrong, since it chose the first list item (tmpl[[1]]). This removes many forms for the visit structure (at least in my real-world example). I changed it accordingly.