### PR TITLE
Factorize meta variables in data tables

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: secuTrialR
 Type: Package
 Title: Handling of data from the clinical data management system secuTrial 
-Version: 0.4.1
+Version: 0.4.2
 Authors@R:
     c(person(given = "Pascal",
              family = "Benkert",

--- a/R/factorize.R
+++ b/R/factorize.R
@@ -81,7 +81,8 @@ factorize_secuTrial.data.frame <- function(data, cl, form, items) {
   meta_var_names <- unique(cl$column[! grepl(".", cl$column, fixed = TRUE)])
 
   str <- strsplit(cl$column, ".", fixed = TRUE)
-  # filters for all which were split by "." the rest is "NA"
+  # split by "." have two entries and the second is needed
+  # the rest has one entry i.e. length(x)
   str <- sapply(str, function(x) x[length(x)])
   cl$var <- str
   w <- cl$column %in% lookups$lookuptable
@@ -92,7 +93,7 @@ factorize_secuTrial.data.frame <- function(data, cl, form, items) {
     lookup <- cl[grepl(paste0(form, ".", name, "$"), cl$column) |
                    (cl$var %in% names(data) & cl$var %in% lookups$ffcolname), ]
     # exception for meta variables (for non meta variables the lookup should never be empty)
-    if (length(lookup$column) == 0 & name %in% meta_var_names) {
+    if (nrow(lookup) == 0 & name %in% meta_var_names) {
       # meta variables do not need to be tied to a form thus the
       # formname does not need to be part of the regex
       lookup <- cl[grepl(paste0("^", name, "$"), cl$column), ]

--- a/R/factorize.R
+++ b/R/factorize.R
@@ -1,5 +1,9 @@
 #' Add factors to secuTrialdata objects
-#' @description secuTrial can return a codebook of codes and labels for categorical variables, including lookup type variables, if this option is selected in the export tool ('reference values as separate table'). This allows factors to be easily created. Factorize methods exist for \code{secuTrialdata} objects, \code{data.frames}, \code{integer}s and \code{logical}s, but the intent is that only the former be used by users. The other methods could be used with customized codebooks.
+#' @description secuTrial can return a codebook of codes and labels for categorical variables, including lookup
+#'              type variables, if this option is selected in the export tool ('reference values as separate table').
+#'              This allows factors to be easily created. Factorize methods exist for \code{secuTrialdata} objects,
+#'              \code{data.frames}, \code{integer}s and \code{logical}s, but the intent is that only the former be
+#'              used by users. The other methods could be used with customized codebooks.
 #' @rdname factorize
 #' @name factorize
 #' @param x a \code{secuTrialdata} object
@@ -18,7 +22,9 @@
 factorize_secuTrial <- function(x, ...) UseMethod("factorize_secuTrial", x)
 
 #' Method for secuTrialdata objects
-#' These objects include all relevant data (assuming that reference values are saved to a separate table, \link[see here for info]{https://swissclinicaltrialorganisation.github.io/secuTrial_recipes/export_data/})
+#' These objects include all relevant data (assuming that reference values are saved to a separate table,
+#' \link[see here for info]{https://swissclinicaltrialorganisation.github.io/secuTrial_recipes/export_data/})
+#'
 #' @rdname factorize
 #' @param object a \code{secuTrialdata} object
 #'
@@ -35,14 +41,20 @@ factorize_secuTrial.secuTrialdata <- function(object) {
 
   x <- object$export_options$data_names
   names(x) <- NULL
+  # not for meta tables
   x <- x[!x %in% object$export_options$meta_names]
-  obs <- lapply(x, function(obj){
-    tmp <- object[[obj]]
-    tmp <- factorize_secuTrial(tmp, object$cl, form = obj, items = object[[object$export_options$meta_names$items]])
-    tmp
+  # factorize for every data table in the export
+  factorized_tables <- lapply(x, function(form_name) {
+    curr_form_data <- object[[form_name]]
+    # passes to factorize_secuTrial.data.frame
+    curr_form_data <- factorize_secuTrial(curr_form_data,
+                                          cl = object$cl,
+                                          form = form_name,
+                                          items = object[[object$export_options$meta_names$items]])
+    curr_form_data
   })
-  obs
-  object[x] <- obs
+  # override with factorized output
+  object[x] <- factorized_tables
   object$export_options$factorized <- TRUE
   object
 }
@@ -58,23 +70,35 @@ factorize_secuTrial.secuTrialdata <- function(object) {
 # # data.frame method
 # nolint end
 factorize_secuTrial.data.frame <- function(data, cl, form, items) {
+  # character reformatting
   if (!is.character(cl$column)) cl$column <- as.character(cl$column)
   if (!is.character(items$ffcolname)) items$ffcolname <- as.character(items$ffcolname)
   if (!is.character(items$lookuptable)) items$lookuptable <- as.character(items$lookuptable)
   lookups <- subset(items, !is.na(items$lookuptable))
   lookups <- unique(lookups[, c("lookuptable", "ffcolname")])
 
+  # needed for the meta variable exception check below
+  meta_var_names <- unique(cl$column[! grepl(".", cl$column, fixed = TRUE)])
+
   str <- strsplit(cl$column, ".", fixed = TRUE)
-  str <- sapply(str, function(x) x[2])
+  # filters for all which were split by "." the rest is "NA"
+  str <- sapply(str, function(x) x[length(x)])
   cl$var <- str
   w <- cl$column %in% lookups$lookuptable
   cl$var[w] <- lookups$ffcolname[match(cl$column[w], lookups$lookuptable)]
 
-  for (i in names(data)[names(data) %in% cl$var]) {
-    lookup <- cl[grepl(paste0(form, ".", i, "$"), cl$column) |
+  for (name in names(data)[names(data) %in% cl$var]) {
+    # lookup for non-meta variables
+    lookup <- cl[grepl(paste0(form, ".", name, "$"), cl$column) |
                    (cl$var %in% names(data) & cl$var %in% lookups$ffcolname), ]
-    data[, paste0(i, ".factor")] <- factorize_secuTrial(data[, i], lookup)
-    data <- .move_column_after(data, paste0(i, ".factor"), i)
+    # exception for meta variables (for non meta variables the lookup should never be empty)
+    if (length(lookup$column) == 0 & name %in% meta_var_names) {
+      # meta variables do not need to be tied to a form thus the
+      # formname does not need to be part of the regex
+      lookup <- cl[grepl(paste0("^", name, "$"), cl$column), ]
+    }
+    data[, paste0(name, ".factor")] <- factorize_secuTrial(data[, name], lookup)
+    data <- .move_column_after(data, paste0(name, ".factor"), name)
   }
   return(data)
 }

--- a/man/factorize.Rd
+++ b/man/factorize.Rd
@@ -19,7 +19,11 @@ factorize_secuTrial(x, ...)
 \code{secuTrialdata} object with extra variables in forms for factors (names are appended with \code{.factor})
 }
 \description{
-secuTrial can return a codebook of codes and labels for categorical variables, including lookup type variables, if this option is selected in the export tool ('reference values as separate table'). This allows factors to be easily created. Factorize methods exist for \code{secuTrialdata} objects, \code{data.frames}, \code{integer}s and \code{logical}s, but the intent is that only the former be used by users. The other methods could be used with customized codebooks.
+secuTrial can return a codebook of codes and labels for categorical variables, including lookup
+             type variables, if this option is selected in the export tool ('reference values as separate table').
+             This allows factors to be easily created. Factorize methods exist for \code{secuTrialdata} objects,
+             \code{data.frames}, \code{integer}s and \code{logical}s, but the intent is that only the former be
+             used by users. The other methods could be used with customized codebooks.
 }
 \details{
 factorize_secuTrial will return an error if the appropriate codebook is not available.

--- a/tests/testthat/test-factorize_secutrial.R
+++ b/tests/testthat/test-factorize_secutrial.R
@@ -1,5 +1,6 @@
 context("factorize")
 
+# BMD
 short_export_location <- system.file("extdata",
                                      "s_export_CSV-xls_BMD.zip",
                                      package = "secuTrialR")
@@ -13,50 +14,51 @@ sT_export_long <- read_secuTrial_export(data_dir = long_export_location)
 
 test_that("separate table warning", expect_error(factorize_secuTrial(sT_export_short)))
 
-
+# CTU05
 dat <- read_secuTrial_export(system.file("extdata", "s_export_CSV-xls_CTU05_longnames_sep_ref.zip",
                                          package = "secuTrialR"))
 
 test_that("error on factorize", expect_warning(factorize_secuTrial(dat), regexp = NA))
 test_that("warning on factorize", expect_error(factorize_secuTrial(dat), regexp = NA))
 
-f <- factorize_secuTrial(dat)
-
-unique(dat$cl$column)
-
 sAF <- options()$stringsAsFactors
 options(stringsAsFactors = FALSE)
 
 dat <- read_secuTrial_export(system.file("extdata", "s_export_CSV-xls_CTU05_longnames_sep_ref.zip",
                                          package = "secuTrialR"))
-f <- factorize_secuTrial(dat)
+fact_dat <- factorize_secuTrial(dat)
+w <- sapply(fact_dat$ctu05ae, class) == "factor"
 
-w <- sapply(f$ctu05ae, class) == "factor"
-names(w)[w]
-
-test_that("number of factors in AE form", expect_equal(sum(w), 8))
+test_that("number of factors in AE form", expect_equal(sum(w), 21))
 
 test_that("Levels in liver cirrhosis", {
-  expect_equal(levels(f$ctu05baseline$liver_cirrh_type.factor), c("C", "B", "A"))
+  expect_equal(levels(fact_dat$ctu05baseline$liver_cirrh_type.factor), c("C", "B", "A"))
 })
 
 test_that("Levels in follow-up", {
-  expect_equal(as.vector(table(f$ctu05outcome$follow_up.factor)), c(5, 5, 2))
-  expect_equal(levels(f$ctu05outcome$follow_up.factor), c("unknown", "ongoing consultation", "death"))
+  expect_equal(as.vector(table(fact_dat$ctu05outcome$follow_up.factor)), c(5, 5, 2))
+  expect_equal(levels(fact_dat$ctu05outcome$follow_up.factor), c("unknown", "ongoing consultation", "death"))
 })
 
 test_that("Levels in SAE", {
-  expect_equal(levels(f$ctu05sae$sae_drug_relation.factor), c("not assessable",
+  expect_equal(levels(fact_dat$ctu05sae$sae_drug_relation.factor), c("not assessable",
                                                               "possible",
                                                               "unlikely",
                                                               "probable",
                                                               "unrelated",
                                                               "definitely"))
-  expect_equal(as.vector(table(f$ctu05sae$sae_drug_relation.factor)), c(1, 1, 0, 0, 0, 0))
+  expect_equal(as.vector(table(fact_dat$ctu05sae$sae_drug_relation.factor)), c(1, 1, 0, 0, 0, 0))
+})
+
+test_that("Levels in meta variables", {
+  expect_equal(levels(fact_dat$ctu05baseline$mnpfcs0.factor), c("empty", "partly filled", "completely filled"))
+  expect_equal(as.vector(table(fact_dat$ctu05baseline$mnpfcs0.factor)), c(0, 3, 14))
+  expect_equal(as.vector(table(fact_dat$ctu05baseline$sigstatus.factor)), c(17, rep(0, 28)))
 })
 
 # warnings for trying to refactorize
-test_that("refactorize warning",
-          expect_warning(factorize_secuTrial(f)))
+test_that("refactorize warning", {
+          expect_warning(factorize_secuTrial(fact_dat))
+})
 
 options(stringsAsFactors = sAF)


### PR DESCRIPTION
With this PR meta variables in the data tables are now factorized too. The code to add this is actually not very long. While I went through the old code I added some comments and changed some variable names for verbosity. I hope this is fine for you @aghaynes 

The only test that failed after the addition of the new feature was "number of factors in AE form", which makes sense since there are now more factors columns. I adjusted it appropriately.