### PR TITLE
adding exception for duplicated factors

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: secuTrialR
 Type: Package
 Title: Handling of data from the clinical data management system secuTrial 
-Version: 0.4.2
+Version: 0.4.3
 Authors@R:
     c(person(given = "Pascal",
              family = "Benkert",

--- a/R/factorize.R
+++ b/R/factorize.R
@@ -102,6 +102,7 @@ factorize_secuTrial.data.frame <- function(data, cl, form, items) {
     # e.g. decoding of mnpptnid to user names can be non-unique
     # for now it is restricted to mnpptnid
     if (any(duplicated(lookup$value)) & name == "mnpptnid") {
+      warning("Duplicate user names found in factorization of mnpptnid.")
       # concat the value with the code for duplication after first
       lookup$value[which(duplicated(lookup$value))] <-
         paste(lookup$value[which(duplicated(lookup$value))],

--- a/R/factorize.R
+++ b/R/factorize.R
@@ -100,13 +100,12 @@ factorize_secuTrial.data.frame <- function(data, cl, form, items) {
     }
     # exception for non-unique entries in the value column of the lookup table
     # e.g. decoding of mnpptnid to user names can be non-unique
-    # needs to be while since something can duplicated more than once
     # for now it is restricted to mnpptnid
-    idx <- 2
-    while (any(duplicated(lookup$value)) & name == "mnpptnid") {
+    if (any(duplicated(lookup$value)) & name == "mnpptnid") {
+      # concat the value with the code for duplication after first
       lookup$value[which(duplicated(lookup$value))] <-
-        paste(lookup$value[which(duplicated(lookup$value))], idx)
-      idx <- idx + 1
+        paste(lookup$value[which(duplicated(lookup$value))],
+              lookup$code[which(duplicated(lookup$value))])
     }
 
     data[, paste0(name, ".factor")] <- factorize_secuTrial(data[, name], lookup)

--- a/R/factorize.R
+++ b/R/factorize.R
@@ -98,6 +98,17 @@ factorize_secuTrial.data.frame <- function(data, cl, form, items) {
       # formname does not need to be part of the regex
       lookup <- cl[grepl(paste0("^", name, "$"), cl$column), ]
     }
+    # exception for non-unique entries in the value column of the lookup table
+    # e.g. decoding of mnpptnid to user names can be non-unique
+    # needs to be while since something can duplicated more than once
+    # for now it is restricted to mnpptnid
+    idx <- 2
+    while (any(duplicated(lookup$value)) & name == "mnpptnid") {
+      lookup$value[which(duplicated(lookup$value))] <-
+        paste(lookup$value[which(duplicated(lookup$value))], idx)
+      idx <- idx + 1
+    }
+
     data[, paste0(name, ".factor")] <- factorize_secuTrial(data[, name], lookup)
     data <- .move_column_after(data, paste0(name, ".factor"), name)
   }

--- a/tests/testthat/test-factorize_secutrial.R
+++ b/tests/testthat/test-factorize_secutrial.R
@@ -70,8 +70,7 @@ duplicate_2$code <- 2019
 dat$cl <- rbind(dat$cl, duplicate_1, duplicate_2)
 
 test_that("Exception for duplicated factor levels in mnpptnid working.", {
-  # this tests for lack of errors, i.e. correct execution
-  expect_error(factorize_secuTrial(dat), NA)
+  expect_warning(factorize_secuTrial(dat))
 })
 
 options(stringsAsFactors = sAF)

--- a/tests/testthat/test-factorize_secutrial.R
+++ b/tests/testthat/test-factorize_secutrial.R
@@ -61,4 +61,17 @@ test_that("refactorize warning", {
           expect_warning(factorize_secuTrial(fact_dat))
 })
 
+# manually adding duplicate factor levels to cl table for mnpptnid
+reference_line <- as.vector(dat$cl[158,])
+duplicate_1 <- reference_line
+duplicate_2 <- reference_line
+duplicate_1$code <- 1987
+duplicate_2$code <- 2019
+dat$cl <- rbind(dat$cl, duplicate_1, duplicate_2)
+
+test_that("Exception for duplicated factor levels in mnpptnid working.", {
+  # this tests for lack of errors, i.e. correct execution
+  expect_error(factorize_secuTrial(dat), NA)
+})
+
 options(stringsAsFactors = sAF)


### PR DESCRIPTION
I triggered this issue as I loaded some real world big dataset. I assume the same user has two accounts on that database. secuTrial decodes to the entered name (which does not have to be unique).

For now I have restricted this exception to mnpptnid. If this issue occurs with any other values we will likely want to know.