### PR TITLE
Factorize repetition variables in short name export

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: secuTrialR
 Type: Package
 Title: Handling of data from the clinical data management system secuTrial 
-Version: 0.4.3
+Version: 0.4.4
 Authors@R:
     c(person(given = "Pascal",
              family = "Benkert",

--- a/tests/testthat/test-factorize_secutrial.R
+++ b/tests/testthat/test-factorize_secutrial.R
@@ -12,65 +12,94 @@ long_export_location <- system.file("extdata",
 sT_export_short <- read_secuTrial_export(data_dir = short_export_location)
 sT_export_long <- read_secuTrial_export(data_dir = long_export_location)
 
-test_that("separate table warning", expect_error(factorize_secuTrial(sT_export_short)))
+test_that("separate table warning", {
+  expect_error(factorize_secuTrial(sT_export_short))
+  expect_error(factorize_secuTrial(sT_export_long))
+})
 
 # CTU05
-dat <- read_secuTrial_export(system.file("extdata", "s_export_CSV-xls_CTU05_longnames_sep_ref.zip",
+ctu05_l <- read_secuTrial_export(system.file("extdata", "s_export_CSV-xls_CTU05_longnames_sep_ref.zip",
                                          package = "secuTrialR"))
 
-test_that("error on factorize", expect_warning(factorize_secuTrial(dat), regexp = NA))
-test_that("warning on factorize", expect_error(factorize_secuTrial(dat), regexp = NA))
+ctu05_s <- read_secuTrial_export(system.file("extdata", "s_export_CSV-xls_CTU05_shortnames_sep_ref.zip",
+                                           package = "secuTrialR"))
+
+test_that("error on factorize", expect_warning(factorize_secuTrial(ctu05_l), regexp = NA))
+test_that("warning on factorize", expect_error(factorize_secuTrial(ctu05_l), regexp = NA))
 
 sAF <- options()$stringsAsFactors
 options(stringsAsFactors = FALSE)
 
-dat <- read_secuTrial_export(system.file("extdata", "s_export_CSV-xls_CTU05_longnames_sep_ref.zip",
-                                         package = "secuTrialR"))
-fact_dat <- factorize_secuTrial(dat)
-w <- sapply(fact_dat$ctu05ae, class) == "factor"
+fact_ctu05_l <- factorize_secuTrial(ctu05_l)
+fact_ctu05_s <- factorize_secuTrial(ctu05_s)
+w_l <- sapply(fact_ctu05_l$ctu05ae, class) == "factor"
+w_s <- sapply(fact_ctu05_s$ae, class) == "factor"
 
-test_that("number of factors in AE form", expect_equal(sum(w), 21))
+test_that("number of factors in AE form", {
+  expect_equal(sum(w_l), 21)
+  expect_equal(sum(w_s), 21)
+})
 
 test_that("Levels in liver cirrhosis", {
-  expect_equal(levels(fact_dat$ctu05baseline$liver_cirrh_type.factor), c("C", "B", "A"))
+  expect_equal(levels(fact_ctu05_l$ctu05baseline$liver_cirrh_type.factor), c("C", "B", "A"))
+  expect_equal(levels(fact_ctu05_s$baseline$liver_cirrh_type.factor), c("C", "B", "A"))
 })
 
 test_that("Levels in follow-up", {
-  expect_equal(as.vector(table(fact_dat$ctu05outcome$follow_up.factor)), c(5, 5, 2))
-  expect_equal(levels(fact_dat$ctu05outcome$follow_up.factor), c("unknown", "ongoing consultation", "death"))
+  expect_equal(as.vector(table(fact_ctu05_l$ctu05outcome$follow_up.factor)), c(5, 5, 2))
+  expect_equal(levels(fact_ctu05_l$ctu05outcome$follow_up.factor), c("unknown", "ongoing consultation", "death"))
+  expect_equal(as.vector(table(fact_ctu05_s$outcome$follow_up.factor)), c(5, 5, 2))
+  expect_equal(levels(fact_ctu05_s$outcome$follow_up.factor), c("unknown", "ongoing consultation", "death"))
 })
 
 test_that("Levels in SAE", {
-  expect_equal(levels(fact_dat$ctu05sae$sae_drug_relation.factor), c("not assessable",
-                                                              "possible",
-                                                              "unlikely",
-                                                              "probable",
-                                                              "unrelated",
-                                                              "definitely"))
-  expect_equal(as.vector(table(fact_dat$ctu05sae$sae_drug_relation.factor)), c(1, 1, 0, 0, 0, 0))
+  expect_equal(levels(fact_ctu05_l$ctu05sae$sae_drug_relation.factor), c("not assessable",
+                                                                         "possible",
+                                                                         "unlikely",
+                                                                         "probable",
+                                                                         "unrelated",
+                                                                         "definitely"))
+  expect_equal(as.vector(table(fact_ctu05_l$ctu05sae$sae_drug_relation.factor)), c(1, 1, 0, 0, 0, 0))
+  expect_equal(levels(fact_ctu05_s$sae$sae_drug_relation.factor), c("not assessable",
+                                                                    "possible",
+                                                                    "unlikely",
+                                                                    "probable",
+                                                                    "unrelated",
+                                                                    "definitely"))
+  expect_equal(as.vector(table(fact_ctu05_s$sae$sae_drug_relation.factor)), c(1, 1, 0, 0, 0, 0))
 })
 
 test_that("Levels in meta variables", {
-  expect_equal(levels(fact_dat$ctu05baseline$mnpfcs0.factor), c("empty", "partly filled", "completely filled"))
-  expect_equal(as.vector(table(fact_dat$ctu05baseline$mnpfcs0.factor)), c(0, 3, 14))
-  expect_equal(as.vector(table(fact_dat$ctu05baseline$sigstatus.factor)), c(17, rep(0, 28)))
+  expect_equal(levels(fact_ctu05_l$ctu05baseline$mnpfcs0.factor), c("empty", "partly filled", "completely filled"))
+  expect_equal(as.vector(table(fact_ctu05_l$ctu05baseline$mnpfcs0.factor)), c(0, 3, 14))
+  expect_equal(as.vector(table(fact_ctu05_l$ctu05baseline$sigstatus.factor))[1], 17)
+  expect_equal(levels(fact_ctu05_s$baseline$mnpfcs0.factor), c("empty", "partly filled", "completely filled"))
+  expect_equal(as.vector(table(fact_ctu05_s$baseline$mnpfcs0.factor)), c(0, 3, 14))
+  expect_equal(as.vector(table(fact_ctu05_s$baseline$sigstatus.factor))[1], 17)
 })
+
+# factorization of reprtitions (subforms)
+test_that("Factorization of repetitions working.", {
+  expect_true(all_equal(fact_ctu05_s$esurgeries, fact_ctu05_l$emnpctu05surgeries))
+})
+
 
 # warnings for trying to refactorize
 test_that("refactorize warning", {
-          expect_warning(factorize_secuTrial(fact_dat))
+  expect_warning(factorize_secuTrial(fact_ctu05_l))
+  expect_warning(factorize_secuTrial(fact_ctu05_s))
 })
 
 # manually adding duplicate factor levels to cl table for mnpptnid
-reference_line <- as.vector(dat$cl[158,])
+reference_line <- as.vector(ctu05_l$cl[158,])
 duplicate_1 <- reference_line
 duplicate_2 <- reference_line
 duplicate_1$code <- 1987
 duplicate_2$code <- 2019
-dat$cl <- rbind(dat$cl, duplicate_1, duplicate_2)
+ctu05_l$cl <- rbind(ctu05_l$cl, duplicate_1, duplicate_2)
 
 test_that("Exception for duplicated factor levels in mnpptnid working.", {
-  expect_warning(factorize_secuTrial(dat))
+  expect_warning(factorize_secuTrial(ctu05_l))
 })
 
 options(stringsAsFactors = sAF)


### PR DESCRIPTION
This fixes the factorize part of #66 and addresses #71 which can likely not be "fixed".

Currently working on the date part of #66 and will also fix #62.

I also added equivalent tests for all existing long name tests for a short name export and checked for equality. 

@markomi also locally ran the version from this PR and it also fixes the issue where the problem was initially discovered.