### PR TITLE
Date warnings

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: secuTrialR
 Type: Package
 Title: Handling of data from the clinical data management system secuTrial 
-Version: 0.5.3
+Version: 0.5.4
 Authors@R:
     c(person(given = "Pascal",
              family = "Benkert",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # secuTrialR 0.5.4
-* `dates_secuTrial()` now warns if not all dates were parsed (expected if there are incomplete dates)
-* `factorize_secuTrial()` now warns if there are issues with the factorization (not expected to trigger)
+* `dates_secuTrial()` now warns if not all dates were parsed (expected if there are incomplete dates).
+* `factorize_secuTrial()` now warns if there are issues with the factorization (not expected to trigger).
 
 # secuTrialR 0.5.2
 * New function `build_secuTrial_url()` has been added. It allows users to easily compose URLs to specific secuTrial forms.
@@ -10,4 +10,4 @@
   to avoid confusion with `read_secuTrial()`.
  
 # secuTrialR 0.4.16
-* As of version 0.4.17, changes will be recorded in the NEWS file
+* As of version 0.4.17, changes will be recorded in the NEWS file.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# secuTrialR 0.5.4
+* `dates_secuTrial()` now warns if not all dates were parsed (expected if there are incomplete dates)
+* `factorize_secuTrial()` now warns if there are issues with the factorization (not expected to trigger)
+
 # secuTrialR 0.5.2
 * New function `build_secuTrial_url()` has been added. It allows users to easily compose URLs to specific secuTrial forms.
 

--- a/R/dates_secuTrial.R
+++ b/R/dates_secuTrial.R
@@ -95,6 +95,11 @@ dates_secuTrial.data.frame <- function(data, datevars, timevars, dateformat, dat
   if (length(datevars) > 0) {
     for (x in datevars) {
       newdatecol <- dates_secuTrial(data[, x], dateformat)
+      # check for conversion of all else warn
+      if (length(which(is.na(newdatecol))) > length(which(is.na(data[, x])))) {
+        warning(paste0("Not all dates were converted for the variable: '", x, "'. ",
+                       "\n  This is likely due to incomplete date entries."))
+      }
       data[, paste0(x, ".date")] <- newdatecol
       data <- .move_column_after(data, paste0(x, ".date"), x)
     }
@@ -105,6 +110,11 @@ dates_secuTrial.data.frame <- function(data, datevars, timevars, dateformat, dat
   if (length(timevars) > 0) {
     for (x in timevars) {
       newdatecol <- datetimes_secuTrial(data[, x], datetimeformat)
+      # check for conversion of all else warn
+      if (length(which(is.na(newdatecol))) > length(which(is.na(data[, x])))) {
+        warning(paste0("Not all dates were converted for the variable: '", x, "'.",
+                       "\n  This is likely due to incomplete date entries."))
+      }
       data[, paste0(x, ".datetime")] <- newdatecol
       data <- .move_column_after(data, paste0(x, ".datetime"), x)
     }

--- a/R/dates_secuTrial.R
+++ b/R/dates_secuTrial.R
@@ -77,7 +77,7 @@ dates_secuTrial.secuTrialdata <- function(object, ...) {
     dateformat <- object$export_options$date_format
     datetimeformat <- object$export_options$datetime_format
     tmp <- object[[obj]]
-    tmp <- dates_secuTrial(tmp, datevars, timevars, dateformat, datetimeformat, ...)
+    tmp <- dates_secuTrial(tmp, datevars, timevars, dateformat, datetimeformat, obj, ...)
   })
   object[table_names] <- obs
   object$export_options$dated <- TRUE
@@ -89,7 +89,7 @@ dates_secuTrial.secuTrialdata <- function(object, ...) {
 # @param data data.frame
 # @param datevars string consisting of variables with dates
 # @param format format of dates (typically taken from \code{object$export_options$date_format})
-dates_secuTrial.data.frame <- function(data, datevars, timevars, dateformat, datetimeformat, warn = FALSE) {
+dates_secuTrial.data.frame <- function(data, datevars, timevars, dateformat, datetimeformat, form, warn = FALSE) {
   datevars <- datevars[datevars %in% names(data)]
   timevars <- timevars[timevars %in% names(data)]
   if (length(datevars) > 0) {
@@ -97,8 +97,10 @@ dates_secuTrial.data.frame <- function(data, datevars, timevars, dateformat, dat
       newdatecol <- dates_secuTrial(data[, x], dateformat)
       # check for conversion of all else warn
       if (length(which(is.na(newdatecol))) > length(which(is.na(data[, x])))) {
-        warning(paste0("Not all dates were converted for the variable: '", x, "'. ",
-                       "\n  This is likely due to incomplete date entries."))
+        warning(paste0("Not all dates were converted for\n",
+                       "  variable: '", x,
+                       "'\n  in form: '", form,
+                       "'\n  This is likely due to incomplete date entries."))
       }
       data[, paste0(x, ".date")] <- newdatecol
       data <- .move_column_after(data, paste0(x, ".date"), x)
@@ -112,8 +114,10 @@ dates_secuTrial.data.frame <- function(data, datevars, timevars, dateformat, dat
       newdatecol <- datetimes_secuTrial(data[, x], datetimeformat)
       # check for conversion of all else warn
       if (length(which(is.na(newdatecol))) > length(which(is.na(data[, x])))) {
-        warning(paste0("Not all dates were converted for the variable: '", x, "'.",
-                       "\n  This is likely due to incomplete date entries."))
+        warning(paste0("Not all dates were converted for\n",
+                       "  variable: '", x,
+                       "'\n  in form: '", form,
+                       "'\n  This is likely due to incomplete date entries."))
       }
       data[, paste0(x, ".datetime")] <- newdatecol
       data <- .move_column_after(data, paste0(x, ".datetime"), x)

--- a/R/factorize.R
+++ b/R/factorize.R
@@ -136,7 +136,8 @@ factorize_secuTrial.data.frame <- function(data, cl, form, items, short_names) {
         #       "at" if shortnames is exported
         # exclude mnpfs variables since 0 is not converted
         ! (grepl("^mnpfs", name) | grepl("^at", form))) {
-      warning(paste("Unexpected: Not all factors converted for:", name))
+      warning(paste("Unexpected: Not all factors converted for:", name,
+                    "In form:", form))
     }
   }
   return(data)

--- a/R/factorize.R
+++ b/R/factorize.R
@@ -128,6 +128,16 @@ factorize_secuTrial.data.frame <- function(data, cl, form, items, short_names) {
 
     data[, paste0(name, ".factor")] <- factorize_secuTrial(data[, name], lookup)
     data <- .move_column_after(data, paste0(name, ".factor"), name)
+    # check for conversion of all else warn // this is expected to never happen
+    if (length(which(is.na(data[, paste0(name, ".factor")]))) >
+        length(which(is.na(data[, name]))) &
+        # exclude audit trail
+        # note: this will also exclude forms with a name starting with
+        #       "at" if shortnames is exported
+        # exclude mnpfs variables since 0 is not converted
+        ! (grepl("^mnpfs", name) | grepl("^at", form))) {
+      warning(paste("Unexpected: Not all factors converted for:", name))
+    }
   }
   return(data)
 }

--- a/R/factorize.R
+++ b/R/factorize.R
@@ -136,8 +136,7 @@ factorize_secuTrial.data.frame <- function(data, cl, form, items, short_names) {
         #       "at" if shortnames is exported
         # exclude mnpfs variables since 0 is not converted
         ! (grepl("^mnpfs", name) | grepl("^at", form))) {
-      warning(paste("Unexpected: Not all factors converted for:", name,
-                    "In form:", form))
+      warning(paste("Unexpected: Not all levels converted for", name, "in form", form))
     }
   }
   return(data)

--- a/README.Rmd
+++ b/README.Rmd
@@ -19,7 +19,8 @@ library(secuTrialR)
 ```
 Load a dataset 
 ```{r}
-export_location <- system.file("extdata", "sT_exports", "longnames", "s_export_CSV-xls_CTU05_long_ref_miss_en_utf8.zip",
+export_location <- system.file("extdata", "sT_exports", "longnames",
+                               "s_export_CSV-xls_CTU05_long_ref_miss_en_utf8.zip",
                                package = "secuTrialR")
 ctu05 <- read_secuTrial(export_location)
 ```

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ library(secuTrialR)
 Load a dataset 
 
 ```r
-export_location <- system.file("extdata", "sT_exports", "longnames", "s_export_CSV-xls_CTU05_long_ref_miss_en_utf8.zip",
+export_location <- system.file("extdata", "sT_exports", "longnames",
+                               "s_export_CSV-xls_CTU05_long_ref_miss_en_utf8.zip",
                                package = "secuTrialR")
 ctu05 <- read_secuTrial(export_location)
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 
 
-# secuTrialR ![travis](https://api.travis-ci.com/SwissClinicalTrialOrganisation/secuTrialR.svg?branch=master) [![codecov](https://codecov.io/github/SwissClinicalTrialOrganisation/secuTrialR/branch/master/graphs/badge.svg)](https://codecov.io/github/SwissClinicalTrialOrganisation/secuTrialR) [![](https://img.shields.io/badge/dev%20version-0.5.3-blue.svg)](https://github.com/SwissClinicalTrialOrganisation/secuTrialR)
+# secuTrialR ![travis](https://api.travis-ci.com/SwissClinicalTrialOrganisation/secuTrialR.svg?branch=master) [![codecov](https://codecov.io/github/SwissClinicalTrialOrganisation/secuTrialR/branch/master/graphs/badge.svg)](https://codecov.io/github/SwissClinicalTrialOrganisation/secuTrialR) [![](https://img.shields.io/badge/dev%20version-0.5.4-blue.svg)](https://github.com/SwissClinicalTrialOrganisation/secuTrialR)
 
 An R package to handle data from the clinical data management system (CDMS) [secuTrial](https://www.secutrial.com/en/).
 
@@ -68,7 +68,7 @@ bmd_export
 ```
 
 ```
-## SecuTrial data imported from /home/markovicm/R/x86_64-suse-linux-gnu-library/3.6/secuTrialR/extdata/sT_exports/BMD/s_export_CSV-xls_BMD_short_en_utf8.zip 
+## SecuTrial data imported from /home/wrightp/R/x86_64-pc-linux-gnu-library/3.4/secuTrialR/extdata/sT_exports/BMD/s_export_CSV-xls_BMD_short_en_utf8.zip 
 ##  table nrow ncol  meta original_name
 ##     vp    1   10  TRUE        vp.xls
 ##   vpfs    1    2  TRUE      vpfs.xls

--- a/tests/testthat/test-annual_recruitment.R
+++ b/tests/testthat/test-annual_recruitment.R
@@ -9,9 +9,12 @@ ldat_ctu05 <- read_secuTrial(system.file("extdata", "sT_exports", "longnames",
 bmd <- read_secuTrial(system.file("extdata", "sT_exports", "BMD",
                                   "s_export_CSV-xls_BMD_short_en_utf8.zip",
                                   package = "secuTrialR"))
+# warning can be suppressed (it is expected)
+suppressWarnings(
 tes05 <- read_secuTrial(system.file("extdata", "sT_exports", "encodings",
                                     "s_export_CSV-xls_TES05_long_ref_en_utf8.zip",
                                     package = "secuTrialR"))
+)
 
 test_that("Test fail", {
   expect_error(annual_recruitment(1337))

--- a/tests/testthat/test-completeness.R
+++ b/tests/testthat/test-completeness.R
@@ -13,13 +13,18 @@ s_ctu05_pl <- read_secuTrial(system.file("extdata", "sT_exports", "shortnames",
                                          package = "secuTrialR"))
 
 # TES05
+# warning can be suppressed (it is expected)
+suppressWarnings(
 s_tes05_iso <- read_secuTrial(system.file("extdata", "sT_exports", "encodings",
                                           "s_export_CSV-xls_TES05_short_ref_en_iso8859-15.zip",
                                           package = "secuTrialR"))
+)
+# warning can be suppressed (it is expected)
+suppressWarnings(
 l_tes05_utf <- read_secuTrial(system.file("extdata", "sT_exports", "encodings",
                                           "s_export_CSV-xls_TES05_long_ref_en_utf8.zip",
                                           package = "secuTrialR"))
-
+)
 
 test_that("Test fail", {
   expect_error(form_status_counts(1337))

--- a/tests/testthat/test-dates_secutrial.R
+++ b/tests/testthat/test-dates_secutrial.R
@@ -164,5 +164,16 @@ test_that("redating creates an error", {
   expect_warning(secuTrialR:::datetimes_secuTrial(e))
 })
 
+# test warnings for incomplete conversion
+path <- system.file("extdata", "sT_exports", "encodings",
+                    "s_export_CSV-xls_TES05_short_ref_en_iso8859-15.zip",
+                    package = "secuTrialR")
+
+tes05_raw <- read_secuTrial_raw(path)
+
+test_that("loading data: TES05 incomplete dates (warn)", {
+  expect_warning(f <- dates_secuTrial(tes05_raw))
+})
+
 # TODO: include tests with a dataset that was exported with duplicate meta data into all tables
 #       include tests with dates and datetimes in repetitions

--- a/tests/testthat/test-visit_structure.R
+++ b/tests/testthat/test-visit_structure.R
@@ -33,9 +33,12 @@ test_that("failure on CTU05 data", {
   expect_error(visit_structure(ldat), regexp = NA)
 })
 
+# warning can be suppressed (it is expected)
+suppressWarnings(
 dat <- read_secuTrial(system.file("extdata", "sT_exports", "encodings",
                                   "s_export_CSV-xls_TES05_short_ref_en_iso8859-15.zip",
                                   package = "secuTrialR"))
+)
 
 test_that("no fail with TES05", {
           expect_error(visit_structure(dat), regexp = NA)


### PR DESCRIPTION
This addresses #32 and also includes a warning for the factorization. I don't expect the warning for the factorization to ever trigger but its better to be safe than sorry.

The dates warnings can definitely trigger (see examples in the tests) and will now no longer silently fail to parse all dates.

As a followup to #32 I suggest that we implement a solution which allows filling missing dates data by a prespecified method. This should, however, not be part of the wrapper but rather be run explicitly after the warning has indicated that certain dates/datetimes were not parsed.