### PR TITLE
Lookupname eq varname

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: secuTrialR
 Type: Package
 Title: Handling of data from the clinical data management system secuTrial 
-Version: 0.6.1
+Version: 0.6.2
 Authors@R:
     c(person(given = "Pascal",
              family = "Benkert",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# secuTrialR 0.6.2
+* `factorize_secuTrial()` now no longer triggers an unexpected warning when the name of a secuTrial lookuptable is equal to the name of the variable it is being used in. (PR #108)
+
 # secuTrialR 0.6.1
 * `return_random_cases()` has been added to the package. It allows to sample a random subset of cases from a secuTrial export in a reproducible fashion.
 

--- a/R/factorize.R
+++ b/R/factorize.R
@@ -104,8 +104,8 @@ factorize_secuTrial.data.frame <- function(data, cl, form, items, short_names) {
     lookup <- cl[grepl(regex_cl, cl$column) |
                    (cl$var %in% names(data) & cl$var %in% lookups$ffcolname), ]
 
-    # exception for meta variables (for non meta variables the lookup should never be empty)
-    if (nrow(lookup) == 0 & name %in% meta_var_names) {
+    # exception for meta variables
+    if (name %in% meta_var_names) {
       # meta variables do not need to be tied to a form thus the
       # formname does not need to be part of the regex
       lookup <- cl[grepl(paste0("^", name, "$"), cl$column), ]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 
 
-# secuTrialR ![travis](https://api.travis-ci.com/SwissClinicalTrialOrganisation/secuTrialR.svg?branch=master) [![codecov](https://codecov.io/github/SwissClinicalTrialOrganisation/secuTrialR/branch/master/graphs/badge.svg)](https://codecov.io/github/SwissClinicalTrialOrganisation/secuTrialR) [![](https://img.shields.io/badge/dev%20version-0.6.1-blue.svg)](https://github.com/SwissClinicalTrialOrganisation/secuTrialR)
+# secuTrialR ![travis](https://api.travis-ci.com/SwissClinicalTrialOrganisation/secuTrialR.svg?branch=master) [![codecov](https://codecov.io/github/SwissClinicalTrialOrganisation/secuTrialR/branch/master/graphs/badge.svg)](https://codecov.io/github/SwissClinicalTrialOrganisation/secuTrialR) [![](https://img.shields.io/badge/dev%20version-0.6.2-blue.svg)](https://github.com/SwissClinicalTrialOrganisation/secuTrialR)
 
 An R package to handle data from the clinical data management system (CDMS) [secuTrial](https://www.secutrial.com/en/).
 


### PR DESCRIPTION
It turns out that there is a problem when the name of a lookuptable (secuTrial) is equal to the name of the variable its being used in. If this is the case then the meta variables are not factorized properly.
It triggers this warning:
`warning(paste("Unexpected: Not all levels converted for", name, "in form", form))`


The fix is removing the `nrow(lookup) == 0` condition. I spent quite some time investigating why I may have put it there in the first place, and as of now I think there is no need. Next to the tests in the package which all still pass without any changes I also made several local checks with private datasets (7 different secuTrial exports including lookuptable data structures). I loaded them before removing the condition and after removing the condition and checked the outputs with `all.equal()`. For all exports except the one that triggered the issue in the first place `all.equal()` returned `TRUE`.

In summary I think this condition can be safely removed because it serves no purpose and creates problems in specific scenarios.
