### PR TITLE
add check for centres being part of the export in return_random_participants()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: secuTrialR
 Type: Package
 Title: Handling of data from the clinical data management system secuTrial 
-Version: 0.8.7
+Version: 0.8.8
 Author:
     c(person(given = "Pascal",
              family = "Benkert",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# secuTrialR 0.8.8
+* added check to make sure that specified centres are part of the export in `return_random_participants()` (#151)
+
 # secuTrialR 0.8.7
 * extended failure comment in `read_secuTrial()` to indicate that the problem could be a rectangular export file (#168)
 * added "Form data of hidden fields" export option information to `export_options` (#171)

--- a/R/return_random_participants.R
+++ b/R/return_random_participants.R
@@ -4,7 +4,7 @@
 #' @param x a \code{secuTrialdata} object
 #' @param centres A character vector of centres for which participants should be returned. If left
 #'                unspecified it will return participants for every study centre.
-#' @param percent A number greater than 0 and smaller than 1 specifying the approximate percantage
+#' @param percent A number greater than 0 and smaller than 1 specifying the approximate percentage
 #'                of participants to be returned per centre.
 #' @param date If only participants after a specific date should be considered this can be entered here.
 #'             Format should be "YYYY-MM-DD" (e.g. "2011-03-26" for March 26th 2011).
@@ -13,7 +13,9 @@
 #' @export
 #' @details return_random_participants will produce a list of two elements. First, a data.frame that contains the
 #'          random participants from each specified centre. This is performed based on a specified seed to retain
-#'          reproducibilty. Second, the configuration of the randomization (i.e. result of \code{RNGkind()})
+#'          reproducibilty. Second, the configuration of the randomization (i.e. result of \code{RNGkind()}).
+#'          If the percentage does not yield an integer for a centre the number is tranformed into an integer
+#'          under application of the \code{ceiling()} function (i.e. it is rounded up).
 #'
 #' @examples
 #' # export location
@@ -38,6 +40,15 @@ return_random_participants <- function(x, centres = "all", percent = 0.1, date =
      # need centre info
      if (! x$export_options$centre_info) {
        stop("Please reexport with Centre information.")
+     }
+     # check for centres being part of the export (github issue #151)
+     if (! "all" %in% centres) {
+       missing_ctr <- centres[which(! centres %in% ctr_table$mnpctrname)]
+       if (length(missing_ctr)) {
+         stop(paste(paste(missing_ctr, collapse = ", "),
+                    "not part of the specified export.\nViable centres are:",
+                    paste(ctr_table$mnpctrname, collapse = ", ")))
+       }
      }
      # 0 and 1 can also be excluded because 0 means nothing
      # and 1 means everything. Both cases are implicitly useless.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 
 
-# secuTrialR ![travis](https://api.travis-ci.com/SwissClinicalTrialOrganisation/secuTrialR.svg?branch=master) [![codecov](https://codecov.io/github/SwissClinicalTrialOrganisation/secuTrialR/branch/master/graphs/badge.svg)](https://codecov.io/github/SwissClinicalTrialOrganisation/secuTrialR) [![](https://img.shields.io/badge/dev%20version-0.8.7-blue.svg)](https://github.com/SwissClinicalTrialOrganisation/secuTrialR) [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/SwissClinicalTrialOrganisation/secuTrialR?branch=master&svg=true)](https://ci.appveyor.com/project/SwissClinicalTrialOrganisation/secuTrialR)
+# secuTrialR ![travis](https://api.travis-ci.com/SwissClinicalTrialOrganisation/secuTrialR.svg?branch=master) [![codecov](https://codecov.io/github/SwissClinicalTrialOrganisation/secuTrialR/branch/master/graphs/badge.svg)](https://codecov.io/github/SwissClinicalTrialOrganisation/secuTrialR) [![](https://img.shields.io/badge/dev%20version-0.8.8-blue.svg)](https://github.com/SwissClinicalTrialOrganisation/secuTrialR) [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/SwissClinicalTrialOrganisation/secuTrialR?branch=master&svg=true)](https://ci.appveyor.com/project/SwissClinicalTrialOrganisation/secuTrialR)
 
 
 An R package to handle data from the clinical data management system (CDMS) [secuTrial](https://www.secutrial.com/en/).

--- a/man/return_random_participants.Rd
+++ b/man/return_random_participants.Rd
@@ -18,7 +18,7 @@ return_random_participants(
 \item{centres}{A character vector of centres for which participants should be returned. If left
 unspecified it will return participants for every study centre.}
 
-\item{percent}{A number greater than 0 and smaller than 1 specifying the approximate percantage
+\item{percent}{A number greater than 0 and smaller than 1 specifying the approximate percentage
 of participants to be returned per centre.}
 
 \item{date}{If only participants after a specific date should be considered this can be entered here.
@@ -34,7 +34,9 @@ There are situations (e.g. randomized monitoring) in which you may want to
 \details{
 return_random_participants will produce a list of two elements. First, a data.frame that contains the
          random participants from each specified centre. This is performed based on a specified seed to retain
-         reproducibilty. Second, the configuration of the randomization (i.e. result of \code{RNGkind()})
+         reproducibilty. Second, the configuration of the randomization (i.e. result of \code{RNGkind()}).
+         If the percentage does not yield an integer for a centre the number is tranformed into an integer
+         under application of the \code{ceiling()} function (i.e. it is rounded up).
 }
 \examples{
 # export location

--- a/tests/testthat/test-return_random_participants.R
+++ b/tests/testthat/test-return_random_participants.R
@@ -47,4 +47,6 @@ test_that("Test output", {
   expect_error(suppressWarnings(return_random_participants(bmd, date = 1999)))
   expect_error(return_random_participants(sT_export_only_col_names))
   expect_error(return_random_participants(sT_export_no_centre_info))
+  expect_error(return_random_participants(bmd, centres = "Not a centre"))
+  expect_error(return_random_participants(bmd, centres = c("Not a centre", "Also not a centre")))
 })


### PR DESCRIPTION
I made all the suggested changes from #151 except for the inclusion of 0 and 1 in the  `percent` argument because I prefer excluding them.

closes #151 