### PR TITLE
Adapt file_tag to new structure of ExportOptions.html

### DIFF
--- a/.github/workflows/render-readme-pkgdown.yaml
+++ b/.github/workflows/render-readme-pkgdown.yaml
@@ -24,11 +24,11 @@ jobs:
 
     - name: Install harfbuzz on macOS
       if: runner.os == 'macOS'
-      run: brew install --cask harfbuzz
+      run: brew install harfbuzz
       
     - name: Install fribidi on macOS
       if: runner.os == 'macOS'
-      run: brew install --cask fribidi
+      run: brew install fribidi
 
     - name: Query dependencies
       run: |

--- a/R/read_export_options.R
+++ b/R/read_export_options.R
@@ -150,7 +150,7 @@ read_export_options <- function(data_dir) {
     first_file_trunc <- gsub(".xls", "", first_file)
     file_tag <- gsub(meta_name_patterns, "", first_file_trunc)
   } else {
-    file_tag <- gsub(pattern = "ExportOptions|(_en|_de|_fr|_it|_sp|_pl).html",
+    file_tag <- gsub(pattern = paste0("ExportOptions|(_",lang,"|).html"),
                      replacement = "",
                      files$Name[study_options_file_idx])
   }

--- a/R/read_export_options.R
+++ b/R/read_export_options.R
@@ -150,7 +150,7 @@ read_export_options <- function(data_dir) {
     first_file_trunc <- gsub(".xls", "", first_file)
     file_tag <- gsub(meta_name_patterns, "", first_file_trunc)
   } else {
-    file_tag <- gsub(pattern = "ExportOptions|.html",
+    file_tag <- gsub(pattern = "ExportOptions|(_en|_de|_fr|_it|_sp|_pl).html",
                      replacement = "",
                      files$Name[study_options_file_idx])
   }

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 secuTrialR
 ==========
 
-[![](https://img.shields.io/badge/dev%20version-1.0.8-blue.svg)](https://github.com/SwissClinicalTrialOrganisation/secuTrialR)
+[![](https://img.shields.io/badge/dev%20version-1.0.9-blue.svg)](https://github.com/SwissClinicalTrialOrganisation/secuTrialR)
 [![](https://www.r-pkg.org/badges/version/secuTrialR?color=green)](https://cran.r-project.org/package=secuTrialR)
 [![AppVeyor Build
 Status](https://ci.appveyor.com/api/projects/status/github/SwissClinicalTrialOrganisation/secuTrialR?branch=master&svg=true)](https://ci.appveyor.com/project/SwissClinicalTrialOrganisation/secuTrialR)


### PR DESCRIPTION
New version of secuTrial (6.1.2.5 - 6.3.2.5) include language tag in filename of ExportOptions. file_tag was assumed to be identical for table names and ExportOptions. Correct code to remove language tag from file tag.